### PR TITLE
Update templates to be more generic and fix an import issue in routes_main.py

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,8 @@
 - [x] Add a copyright notice to code and webpages
 - [ ] Add a feature to automatically load the `initial_questions.json` on first startup or deployment
 - [ ] Add a version to the footer of the webpages like copyright notice
-- [x] Automate the deployment of webapp to Ploomber with Github Actions
-  - [x] [Ploomber-Cloud.yaml](https://github.com/ploomber/cloud-template/blob/main/.github/workflows/ploomber-cloud.yaml)
-  - [x] [Ploomber Github Deployments](https://docs.cloud.ploomber.io/en/latest/user-guide/github.html)
-  - [x] "Github Deploy" on the three dots options has details on deployment
-- [ ] Add Dependabot to the Github repository
-  - [x] Add the Python (PIP) based review of libraries
+- [ ] Add a dependency checker to the Github repository
+  - [x] Add Dependabot for the Python (PIP) based review of libraries
   - [ ] Add something for the Bootstrap5 and other CDN components
   - [ ] [Renovate Bot GitHub Action](https://github.com/marketplace/actions/renovate-bot-github-action) [Github Code](https://github.com/renovatebot/github-action)
 - [ ] Make the "Correct: Yes/No" either red or green and bold in the submitQuiz() function in quiz.html

--- a/app.py
+++ b/app.py
@@ -3,14 +3,17 @@
 Copyright © 2024 J. Michael McGarrah <mcgarrah@gmail.com>
 """
 
-from flask import Flask  # Flask framework
-from flask_migrate import Migrate # Flask Database Migration
+from flask import Flask
+from flask_migrate import Migrate
 
-# Import models and routes
-from modules.models import db  # Database instance from models
-from modules.routes_main import *  # Main route handlers (explicitly defined in __all__)
-from modules.routes_quiz import quiz, check_answers  # Quiz-specific route handlers
-from modules.routes_settings import settings, update_settings  # Settings-specific route handlers
+# Import models and routes using absolute imports
+from modules.models import db
+from modules.routes_main import ( import_questions, export_questions, clear_questions,
+                                    add_question, delete_question,
+                                    home, edit_questions,
+                                    edit_categories, add_category, delete_category )
+from modules.routes_quiz import quiz, check_answers
+from modules.routes_settings import settings, update_settings
 
 # Initialize the Flask application
 app = Flask(__name__)

--- a/modules/routes_main.py
+++ b/modules/routes_main.py
@@ -4,12 +4,6 @@ Main routes for the Legendary Quick Quiz application.
 Copyright © 2024 J. Michael McGarrah <mcgarrah@gmail.com>
 """
 
-# allow for star imports with explicit list of functions exported
-__all__ = [ 'import_questions', 'export_questions', 'clear_questions',
-            'add_question', 'delete_question',
-            'home', 'edit_questions',
-            'edit_categories', 'add_category', 'delete_category' ]
-
 # TODO: Break up the functions in this file into separate files
 #   Questions import/export/clear
 #   Question CRUD Add/Del/Modify (edit should become edit_question)
@@ -21,8 +15,8 @@ from modules.models import db, Category, Question
 
 def import_questions():
     """
-    Import questions from a JSON file that either uploaded or the default file in root of webapp 
-    and add them to the database.
+    Import questions from a JSON file that either uploaded or the default
+    file in root of webapp and adds questions and categories to the database.
     """
     file = request.files.get('file')
     if not file:
@@ -52,7 +46,9 @@ def import_questions():
     return redirect(url_for('settings'))
 
 def export_questions():
-    """Export the categories and questions from database to a JSON file"""
+    """
+    Export the categories and questions from database to a JSON file.
+    """
     categories = Category.query.all()
     export_data = []
 
@@ -99,7 +95,9 @@ def clear_questions():
     return redirect(url_for('settings'))
 
 def home():
-    """Home page to pick the quiz category"""
+    """
+    Renders the home page for selecting quiz categories.
+    """
     categories = Category.query.all()
     return render_template('select_category.html', categories=categories)
 
@@ -109,9 +107,13 @@ def edit_questions():
     """
     categories = Category.query.all()
     questions = Question.query.all()
-    return render_template('edit_questions.html', categories=categories, questions=questions, json=json)
+    return render_template('edit_questions.html', categories=categories, 
+                           questions=questions, json=json)
 
 def add_question():
+    """
+    Adds a new question to the database with options, answer, details, and category.
+    """
     options = request.form.getlist('options')
     new_question = Question(
         question=request.form['question'],
@@ -126,16 +128,25 @@ def add_question():
     return redirect(url_for('edit_questions'))
 
 def delete_question(question_id):
+    """
+    Deletes a question from the database by its ID.
+    """
     question = Question.query.get_or_404(question_id)
     db.session.delete(question)
     db.session.commit()
     return redirect(url_for('edit_questions'))
 
 def edit_categories():
+    """
+    Renders the page for editing categories.
+    """
     categories = Category.query.all()
     return render_template('edit_categories.html', categories=categories)
 
 def add_category():
+    """
+    Adds a new category to the database.
+    """
     new_category_name = request.form['category_name']
     new_category = Category(name=new_category_name)
     db.session.add(new_category)
@@ -143,6 +154,9 @@ def add_category():
     return redirect(url_for('edit_categories'))
 
 def delete_category(category_id):
+    """
+    Deletes a category and its associated questions by ID.
+    """
     category = Category.query.get_or_404(category_id)
     # Delete all questions associated with the category
     Question.query.filter_by(category_id=category_id).delete()

--- a/modules/routes_quiz.py
+++ b/modules/routes_quiz.py
@@ -1,12 +1,19 @@
 """
 Copyright © 2024 J. Michael McGarrah <mcgarrah@gmail.com>
 """
-from flask import render_template, request, jsonify
-from modules.models import db, Question, Setting
 import json
 import random
+from flask import render_template, request, jsonify
+from modules.models import Question, Setting
 
 def quiz(category_id):
+    """
+    Retrieves questions based on the category ID.
+    Reads timer and number of questions settings.
+    Randomly shuffles the questions.
+    Conditionally shuffles the question options based on the no_shuffle attribute.
+    Serializes the questions and renders the quiz template.
+    """
     questions = Question.query.filter_by(category_id=category_id).all()
     timer_setting = Setting.query.filter_by(name='timer_duration').first()
     num_questions_setting = Setting.query.filter_by(name='num_questions').first()
@@ -36,6 +43,11 @@ def quiz(category_id):
     return render_template('quiz.html', questions=serialized_questions, timer_duration=timer_duration)
 
 def check_answers():
+    """
+    Processes the user's answers.
+    Compares them with the correct answers.
+    Calculates the score and returns the results in JSON format.
+    """
     data = request.json
     user_answers = data['answers']
     question_ids = data['question_ids']

--- a/modules/routes_settings.py
+++ b/modules/routes_settings.py
@@ -5,6 +5,11 @@ from flask import render_template, request, redirect, url_for
 from modules.models import db, Setting
 
 def settings():
+    """
+    Retrieves the current settings for `timer_duration` and `num_questions`.
+    Uses default values if settings are not found.
+    Renders the `settings.html` template with these values.
+    """
     timer_setting = Setting.query.filter_by(name='timer_duration').first()
     num_questions_setting = Setting.query.filter_by(name='num_questions').first()
     timer_duration = int(timer_setting.value) if timer_setting else 300
@@ -12,6 +17,12 @@ def settings():
     return render_template('settings.html', timer_duration=timer_duration, num_questions=num_questions)
 
 def update_settings():
+    """
+    Updates the settings for timer_duration and num_questions based on the form submission.
+    Checks if the settings exist; if not, creates new settings.
+    Commits the changes to the database.
+    Redirects to the settings page.
+    """
     timer_duration = request.form['timer_duration']
     num_questions = request.form['num_questions']
 

--- a/templates/default.html
+++ b/templates/default.html
@@ -1,29 +1,22 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}{% endblock %}</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+</head>
+<body>
+    {% include 'navbar.html' %}
+    <div class="container mt-4">
+        {% block content %}{% endblock %}
+    </div>
+    {% include 'footer.html' %}
+    <!-- Bootstrap and jQuery Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.4/src/core.min.js"></script>
-
-    <!-- TODO: Fix this next section. This script block is likely in the wrong place... but I hacked it in for the edit_questions.html javascript -->
     {% block scripts %}{% endblock %}
-</head>
-<body>
-
-    <!-- TODO: Make a header with navbar template file here -->
-
-    {% block content %}{% endblock %}
-
-    <!-- TODO: Break out as footer template file -->
-    <footer class="text-center">
-        {% block footer %}
-            <small>Copyright &copy; 2024–<script>document.write(new Date().getFullYear())</script> <a href="https://github.com/mcgarrah">Michael McGarrah</a>
-            </small>
-        {% endblock %}
-    </footer>
-
 </body>
 </html>

--- a/templates/edit_categories.html
+++ b/templates/edit_categories.html
@@ -4,13 +4,9 @@
 
 {% block content %}
 <div class="container mt-4">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="/">Home</a>
-        <a class="navbar-brand" href="/edit_questions">Edit Questions</a>
-        <a class="navbar-brand" href="/settings">Settings</a>
-    </nav>
+    <h1 class="mt-4">Edit Categories</h1>
 
-    <h1 class="mt-4">Existing Categories</h2>
+    <h2 class="mt-4">Existing Categories</h2>
     <ul class="list-group">
         {% for category in categories %}
             <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -22,7 +18,7 @@
         {% endfor %}
     </ul>
 
-    <h2 class="mt-4">Edit Categories</h1>
+    <h2 class="mt-4">Add New Category</h2>
     <form action="/add_category" method="POST" class="mt-4">
         <div class="form-group">
             <label for="category_name">Category Name:</label>
@@ -30,6 +26,5 @@
         </div>
         <button type="submit" class="btn btn-success mt-3">Add Category</button>
     </form>
-
 </div>
 {% endblock %}

--- a/templates/edit_categories.html
+++ b/templates/edit_categories.html
@@ -7,6 +7,7 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <a class="navbar-brand" href="/">Home</a>
         <a class="navbar-brand" href="/edit_questions">Edit Questions</a>
+        <a class="navbar-brand" href="/settings">Settings</a>
     </nav>
 
     <h1 class="mt-4">Existing Categories</h2>

--- a/templates/edit_questions.html
+++ b/templates/edit_questions.html
@@ -4,10 +4,6 @@
 
 {% block content %}
 <div class="container mt-4">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="/">Home</a>
-        <a class="navbar-brand" href="/settings">Settings</a>
-    </nav>
     <h1 class="mt-4">Edit Questions</h1>
     <form action="/add_question" method="POST">
         <div class="form-group">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,0 +1,4 @@
+<footer class="text-center mt-4">
+    <small>Copyright &copy; 2024–<script>document.write(new Date().getFullYear())</script> <a href="https://github.com/mcgarrah">Michael McGarrah</a>
+    </small>
+</footer>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,0 +1,21 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="/">Home</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a class="nav-link" href="/settings">Settings</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/edit_questions">Edit Questions</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/edit_categories">Edit Categories</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>

--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -4,10 +4,6 @@
 
 {% block content %}
 <div class="container mt-4">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="/">Home</a>
-        <a class="navbar-brand" href="/settings">Settings</a>
-    </nav>
     <div id="timer" class="my-4 display-4 font-weight-bold">Time Remaining: <span id="time">{{ '%02d:%02d' % (timer_duration // 60, timer_duration % 60) }}</span></div>
     <form id="quizForm">
         <input type="hidden" id="question_ids" name="question_ids" value="{{ questions|map(attribute='id')|list|tojson }}">
@@ -22,6 +18,9 @@
     </form>
     <div id="result" class="mt-4"></div>
 </div>
+{% endblock %}
+
+{% block scripts %}
 <script>
     let timeLeft = {{ timer_duration }};
     const timerElement = document.getElementById('time');

--- a/templates/select_category.html
+++ b/templates/select_category.html
@@ -4,12 +4,7 @@
 
 {% block content %}
 <div class="container mt-4">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="/">Home</a>
-        <a class="navbar-brand" href="/edit_questions">Edit Questions</a>
-        <a class="navbar-brand" href="/settings">Settings</a>
-    </nav>
-    <h1 class="mt-4">Available Categories</h2>
+    <h1 class="mt-4">Available Categories</h1>
     <ul class="list-group">
         {% for category in categories %}
             <li class="list-group-item d-flex justify-content-between align-items-center">
@@ -19,7 +14,7 @@
         {% endfor %}
     </ul>
 
-    <h2 class="mt-4">Select Category</h1>
+    <h2 class="mt-4">Select Category</h2>
     <form id="categoryForm" class="mt-4">
         <div class="form-group">
             <label for="category_id">Select a category:</label>
@@ -31,9 +26,11 @@
         </div>
         <button type="button" class="btn btn-primary mt-3" onclick="startQuiz()">Start Quiz</button>
     </form>
-
 </div>
 
+{% endblock %}
+
+{% block scripts %}
 <script>
     function startQuiz() {
         const categoryId = document.getElementById('category_id').value;

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,10 +4,6 @@
 
 {% block content %}
 <div class="container mt-4">
-    <nav class="navbar navbar-expand-lg navbar-light bg-light">
-        <a class="navbar-brand" href="/">Home</a>
-        <a class="navbar-brand" href="/edit_questions">Edit Questions</a>
-    </nav>
     <h1 class="mt-4">Settings</h1>
     <form action="/update_settings" method="POST">
         <div class="form-group">


### PR DESCRIPTION
Update templates to be more generic and fix an import issue in routes_main.py

- Revert routes_main.py module import to use explicit function entry points
- Add comments to most functions with more descriptive explanation of what they do
- Update the default.html template to use navbar and footers.
- Fixed default.html to move the scripts to the bottom of the webpage render process.
- Update all templates for webpages to use the default.html navbar and footer sections
- Fix an uncaught bug in select_category.html template with mismatched h1/h2 blocks